### PR TITLE
Adds Support for logoutOtherDevices Method

### DIFF
--- a/src/EventMap.php
+++ b/src/EventMap.php
@@ -17,5 +17,9 @@ trait EventMap
         'Illuminate\Auth\Events\Logout' => [
             'Yadahan\AuthenticationLog\Listeners\LogSuccessfulLogout',
         ],
+
+        'Illuminate\Auth\Events\OtherDeviceLogout' => [
+            'Yadahan\AuthenticationLog\Listeners\LogOtherDevicesLogout',
+        ],
     ];
 }

--- a/src/Listeners/LogOtherDevicesLogout.php
+++ b/src/Listeners/LogOtherDevicesLogout.php
@@ -41,7 +41,7 @@ class LogOtherDevicesLogout
             $currentUserAgent = $this->request->userAgent();
             $currentAuthLog = $currentUser->authentications()->whereIpAddress($currentUserIp)->whereUserAgent($currentUserAgent)->first();
 
-            if (!$currentAuthLog) {
+            if (! $currentAuthLog) {
                 $currentAuthLog = new AuthenticationLog([
                     'ip_address' => $currentUserIp,
                     'user_agent' => $currentUserAgent,

--- a/src/Listeners/LogOtherDevicesLogout.php
+++ b/src/Listeners/LogOtherDevicesLogout.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Yadahan\AuthenticationLog\Listeners;
+
+use Illuminate\Auth\Events\OtherDeviceLogout;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Yadahan\AuthenticationLog\AuthenticationLog;
+
+class LogOtherDevicesLogout
+{
+    /**
+     * The request.
+     *
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
+
+    /**
+     * Create the event listener.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  Logout  $event
+     * @return void
+     */
+    public function handle(OtherDeviceLogout $event)
+    {
+        if ($event->user) {
+            $currentUser = $event->user;
+            $currentUserIp = $this->request->ip();
+            $currentUserAgent = $this->request->userAgent();
+            $currentAuthLog = $currentUser->authentications()->whereIpAddress($currentUserIp)->whereUserAgent($currentUserAgent)->first();
+
+            if (!$currentAuthLog) {
+                $currentAuthLog = new AuthenticationLog([
+                    'ip_address' => $currentUserIp,
+                    'user_agent' => $currentUserAgent,
+                ]);
+            }
+
+            foreach ($currentUser->authentications as $authLog) {
+                if ($authLog->id != $currentAuthLog->id) {
+                    $authLog->logout_at = Carbon::now();
+                    $authLog->save();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for Laravel's logoutOtherDevices method (Ref #30)

Note: While logoutOtherDevices method will logout all logged-in users (except for the current requesting user) out of the system and this pr will mark their auth_log as logged out, it will not trigger a new device alert when the user on the other device logs back in (since the other device is still recognized as a valid/existing device). 

Ref Laravel Docs for [logoutOtherDevices](https://laravel.com/docs/8.x/authentication#invalidating-sessions-on-other-devices) method.