### PR TITLE
Use application langPath method to determine language directory

### DIFF
--- a/src/AuthenticationLogServiceProvider.php
+++ b/src/AuthenticationLogServiceProvider.php
@@ -34,7 +34,7 @@ class AuthenticationLogServiceProvider extends ServiceProvider
             ], 'authentication-log-views');
 
             $this->publishes([
-                __DIR__.'/../resources/lang' => resource_path('lang/vendor/authentication-log'),
+                __DIR__.'/../resources/lang' => $this->app->langPath('vendor/authentication-log'),
             ], 'authentication-log-translations');
 
             $this->publishes([


### PR DESCRIPTION
Instead of publishing language files directly in the resource_path(), it is better to use the langPath() method of the Illuminate Application.

`$this->app->langPath('vendor/authentication-log')`

If published directly to resources/lang/ the loading of the application language files breaks, as Laravel >=8 checks for the existence of the resources/lang/ directory to determine the language files path.

In L10:
```
$this->useLangPath(value(function () {
            return is_dir($directory = $this->resourcePath('lang'))
                        ? $directory
                        : $this->basePath('lang');
}));
```